### PR TITLE
feat: Add Sentio support in parser button and add related config setting

### DIFF
--- a/src/common/constants/support.ts
+++ b/src/common/constants/support.ts
@@ -548,6 +548,37 @@ export const DEDAUB_SUPPORT_DIRECT_LIST = [
   }
 ]
 
+export const SENTIO_SUPPORT_LIST = [
+  {
+    chain: 'eth',
+    pathname: '1'
+  },
+  {
+    chain: 'polygon',
+    pathname: '137'
+  },
+  {
+    chain: 'bsc',
+    pathname: '56'
+  },
+  {
+    chain: 'moonbeam',
+    pathname: '1284'
+  },
+  {
+    chain: 'linea',
+    pathname: '59144'
+  },
+  {
+    chain: 'gor.eth',
+    pathname: '5'
+  },
+  {
+    chain: 'sepolia.eth',
+    pathname: '11155111'
+  }
+]
+
 export const ETHERSCAN_DETH_SUPPORT_LIST = [
   {
     chain: 'eth',
@@ -697,6 +728,7 @@ export class TransactionParsers extends BaseConstant {
     'dedaub',
     'https://library.dedaub.com'
   )
+  static SENTIO = new BaseConstant('sentio', 'sentio', 'https://app.sentio.xyz')
 }
 
 export const PROXY_LOG_SUPPORT_LIST = [

--- a/src/content/etherscan/components/ParsersBtn/index.tsx
+++ b/src/content/etherscan/components/ParsersBtn/index.tsx
@@ -6,7 +6,8 @@ import {
   PHALCON_SUPPORT_LIST,
   TENDERLY_SUPPORT_LIST,
   OPENCHAIN_SUPPORT_LIST,
-  TransactionParsers
+  TransactionParsers,
+  SENTIO_SUPPORT_LIST
 } from '@common/constants'
 import { useStore } from '@common/hooks'
 import { getNodeValue } from '@common/utils'
@@ -33,6 +34,9 @@ const ParsersBtn: FC<Props> = ({ chain }) => {
     item => item.chain === chain
   )?.pathname
   const tenderlyPathname = TENDERLY_SUPPORT_LIST.find(
+    item => item.chain === chain
+  )?.pathname
+  const sentioPathname = SENTIO_SUPPORT_LIST.find(
     item => item.chain === chain
   )?.pathname
 
@@ -76,6 +80,16 @@ const ParsersBtn: FC<Props> = ({ chain }) => {
               rel="noopener noreferrer"
             >
               Dedaub
+            </a>
+          )}
+        {sentioPathname &&
+          alternativeParsers[TransactionParsers.SENTIO.value()] && (
+            <a
+              href={`https://app.sentio.xyz/tx/${sentioPathname}/${txHash}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Sentio
             </a>
           )}
       </Space>

--- a/src/content/scans/components/ParsersBtn/index.tsx
+++ b/src/content/scans/components/ParsersBtn/index.tsx
@@ -6,7 +6,8 @@ import {
   PHALCON_SUPPORT_LIST,
   TENDERLY_SUPPORT_LIST,
   OPENCHAIN_SUPPORT_LIST,
-  TransactionParsers
+  TransactionParsers,
+  SENTIO_SUPPORT_LIST
 } from '@common/constants'
 import { getNodeValue } from '@common/utils'
 import { useStore } from '@common/hooks'
@@ -33,6 +34,9 @@ const ParsersBtn: FC<Props> = ({ chain }) => {
     item => item.chain === chain
   )?.pathname
   const tenderlyPathname = TENDERLY_SUPPORT_LIST.find(
+    item => item.chain === chain
+  )?.pathname
+  const sentioPathname = SENTIO_SUPPORT_LIST.find(
     item => item.chain === chain
   )?.pathname
 
@@ -76,6 +80,16 @@ const ParsersBtn: FC<Props> = ({ chain }) => {
               rel="noopener noreferrer"
             >
               Dedaub
+            </a>
+          )}
+        {sentioPathname &&
+          alternativeParsers[TransactionParsers.SENTIO.value()] && (
+            <a
+              href={`https://app.sentio.xyz/tx/${sentioPathname}/${txHash}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Sentio
             </a>
           )}
       </Space>

--- a/src/content/snowtrace/components/ParsersBtn/index.tsx
+++ b/src/content/snowtrace/components/ParsersBtn/index.tsx
@@ -6,7 +6,8 @@ import {
   PHALCON_SUPPORT_LIST,
   TENDERLY_SUPPORT_LIST,
   OPENCHAIN_SUPPORT_LIST,
-  TransactionParsers
+  TransactionParsers,
+  SENTIO_SUPPORT_LIST
 } from '@common/constants'
 import { useStore } from '@common/hooks'
 
@@ -30,6 +31,9 @@ const ParsersBtn: FC<Props> = ({ chain, txHash }) => {
     item => item.chain === chain
   )?.pathname
   const tenderlyPathname = TENDERLY_SUPPORT_LIST.find(
+    item => item.chain === chain
+  )?.pathname
+  const sentioPathname = SENTIO_SUPPORT_LIST.find(
     item => item.chain === chain
   )?.pathname
 
@@ -77,6 +81,16 @@ const ParsersBtn: FC<Props> = ({ chain, txHash }) => {
               className="text-primary link"
             >
               Dedaub
+            </a>
+          )}
+        {sentioPathname &&
+          alternativeParsers[TransactionParsers.SENTIO.value()] && (
+            <a
+              href={`https://app.sentio.xyz/tx/${sentioPathname}/${txHash}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Sentio
             </a>
           )}
       </Space>

--- a/src/popup/components/Settings/components/ConfigExploresDrawer/index.tsx
+++ b/src/popup/components/Settings/components/ConfigExploresDrawer/index.tsx
@@ -187,6 +187,20 @@ const ConfigExploresDrawer: FC<Props> = ({
                       }
                     />
                   </Space>
+                  <Space>
+                    <span style={{ fontSize: 'inherit' }}>Sentio</span>
+                    <Checkbox
+                      checked={
+                        alternativeParsers[TransactionParsers.SENTIO.value()]
+                      }
+                      onChange={e =>
+                        onAlternativeParsersChange(
+                          TransactionParsers.SENTIO.value(),
+                          e.target.checked
+                        )
+                      }
+                    />
+                  </Space>
                 </div>
               }
             />

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -103,7 +103,8 @@ export const defaultValue: StorageInfo = {
   alternativeParsers: {
     [TransactionParsers.OPENCHAIN.name()]: true,
     [TransactionParsers.TENDERLY.name()]: true,
-    [TransactionParsers.DEDAUB.name()]: false
+    [TransactionParsers.DEDAUB.name()]: false,
+    [TransactionParsers.SENTIO.name()]: true
   }
 }
 


### PR DESCRIPTION
This PR adds support of Sentio transaction analysis service in these sites:
* etherscan
* scans
* snowtrace

Related setting config is added as well.
<img width="411" alt="image" src="https://github.com/blocksecteam/metadock/assets/1532735/9aa574f7-cd95-435d-8400-617a74c51974">
