### PR TITLE
chore: update node version requirement in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ git clone https://github.com/blocksecteam/metasuites.git --recurse-submodules
 
 ## Installing Node.js
 
-You need to install Node.js v18.12.0 or higher. You can run the following commands in your terminal to check your local Node.js versions:
+You need to install Node.js v18.18.0. You can run the following commands in your terminal to check your local Node.js versions:
 
 ```shell
 node -v


### PR DESCRIPTION
Currently Node version is pinned to 18.18.0 in `package.json` which won't allow using any other version. 
https://github.com/blocksecteam/metasuites/blob/26c9555d2592096840b18fb6aeb3e97eabedaf4a/package.json#L9

Not sure about such a strict node version requirement, but current contributing docs are misleading