### PR TITLE
feat: support Decompile in Dedaub on BSC

### DIFF
--- a/src/common/constants/support.ts
+++ b/src/common/constants/support.ts
@@ -685,6 +685,10 @@ export const DEDAUB_SUPPORT_DIRECT_LIST = [
     pathname: 'ethereum'
   },
   {
+    chain: 'bsc',
+    pathname: 'binance'
+  },
+  {
     chain: 'fantom',
     pathname: 'fantom'
   },


### PR DESCRIPTION
Dedaub already fully supports Binance Smart Chain (BSC). This commit adds the BSC pathname (`binance`) to the `DEDAUB_SUPPORT_DIRECT_LIST`, enabling direct redirection to `https://app.dedaub.com/binance/address/*`.

Before:
<img width="1045" alt="image" src="https://github.com/user-attachments/assets/a3f1184c-c68e-42ef-b985-d2bcd526108b">
After:
![image](https://github.com/user-attachments/assets/2b581923-29e4-4eb0-b56c-1741532a595e)
