### PR TITLE
fix: Update Arkham Intel domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For up to the minute news, follow our [Twitter](https://twitter.com/MetaDockTeam
 - era.zksync.network
 - blockscout.com
 - debank.com
-- platform.arkhamintelligence.com
+- intel.arkm.com
 - scan.merlinchain.io
 - solscan.io
 - solana.fm

--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -59,7 +59,7 @@ export default defineManifest((env: ConfigEnv) => {
               '*://*.metasleuth.io/*',
               '*://explorer.solana.com/*',
               '*://debank.com/*',
-              '*://platform.arkhamintelligence.com/*',
+              '*://intel.arkm.com/*',
               '*://explorer.jito.wtf/*',
               '*://*.blocksec.com/*'
             ]

--- a/src/common/config/allowlist.ts
+++ b/src/common/config/allowlist.ts
@@ -42,7 +42,7 @@ export default {
   SOLANA_EXPLORER_MATCHES: ['*://explorer.solana.com/*'],
   MS_MATCHES: ['*://*.metasleuth.io/*'],
   DEBANK_MATCHES: ['*://debank.com/*'],
-  ARKHAM_MATCHES: ['*://platform.arkhamintelligence.com/*'],
+  ARKHAM_MATCHES: ['*://intel.arkm.com/*'],
   DEX_MATCHES: ['*://dexscreener.com/*'],
   JITO_MATCHES: ['*://explorer.jito.wtf/bundle/*']
 }

--- a/src/common/constants/support.ts
+++ b/src/common/constants/support.ts
@@ -462,7 +462,7 @@ export const EXT_SUPPORT_WEB_LIST: ExtSupportWebsite[] = [
   },
   {
     name: 'Arkham',
-    domains: ['platform.arkhamintelligence.com'],
+    domains: ['intel.arkm.com'],
     siteName: 'ARKHAM',
     logo: 'https://assets.blocksec.com/image/1716165286476-2.svg'
   },


### PR DESCRIPTION
https://x.com/arkham/status/1854567927426826516

> \> Access the intel platform from https://intel.arkm.com
> \> http://platform.arkhamintelligence.com will now redirect to http://intel.arkm.com 
> ...
> \> http://arkhamintelligence.com will redirect to the platform at http://intel.arkm.com
