### PR TITLE
feat: add Routescan-hosted explorer support

### DIFF
--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -43,7 +43,17 @@ export default defineManifest((env: ConfigEnv) => {
               '*://mantlescan.xyz/*',
               '*://opbnb-testnet.bscscan.com/*',
               '*://monadscan.com/*',
-              '*://testnet.monadscan.com/*'
+              '*://testnet.monadscan.com/*',
+              '*://snowtrace.io/*',
+              '*://testnet.snowtrace.io/*',
+              '*://flarescan.com/*',
+              '*://*.flarescan.com/*',
+              '*://chiliscan.com/*',
+              '*://testnet.chiliscan.com/*',
+              '*://explorer.metis.com/*',
+              '*://testnet.explorer.metis.com/*',
+              '*://bobascan.com/*',
+              '*://testnet.bobascan.com/*'
             ]
           : ['<all_urls>'],
         js: ['src/content/index.all_frames.ts'],

--- a/src/common/config/allowlist.ts
+++ b/src/common/config/allowlist.ts
@@ -30,7 +30,17 @@ export default {
     '*://mantlescan.xyz/*',
     '*://sonicscan.org/*',
     '*://monadscan.com/*',
-    '*://testnet.monadscan.com/*'
+    '*://testnet.monadscan.com/*',
+    '*://snowtrace.io/*',
+    '*://testnet.snowtrace.io/*',
+    '*://flarescan.com/*',
+    '*://*.flarescan.com/*',
+    '*://chiliscan.com/*',
+    '*://testnet.chiliscan.com/*',
+    '*://explorer.metis.com/*',
+    '*://testnet.explorer.metis.com/*',
+    '*://bobascan.com/*',
+    '*://testnet.bobascan.com/*'
   ],
   BTC_EXPLORER_MATCHES: ['*://explorer.cloverpool.com/*'],
   BLOCKSEC_MATCHES: ['*://*.blocksec.com/*'],

--- a/src/common/constants/support.ts
+++ b/src/common/constants/support.ts
@@ -178,6 +178,104 @@ export const EXT_SUPPORT_WEB_LIST: ExtSupportWebsite[] = [
     logo: 'https://assets.blocksec.com/image/1671777583236-3.png'
   },
   {
+    name: 'Avalanche (Routescan)',
+    chainID: 43114,
+    chain: 'avalanche',
+    domains: ['snowtrace.io'],
+    siteName: 'ETHERSCAN',
+    logo: 'https://assets.blocksec.com/image/1671777583236-3.png',
+    testNets: [
+      {
+        name: 'Avalanche Fuji (Routescan)',
+        chainID: 43113,
+        chain: 'test.avalanche',
+        domains: ['testnet.snowtrace.io'],
+        siteName: 'ETHERSCAN',
+        logo: 'https://assets.blocksec.com/image/1671777583236-3.png'
+      }
+    ]
+  },
+  {
+    name: 'Flare',
+    chainID: 14,
+    chain: 'flare',
+    domains: ['flarescan.com'],
+    siteName: 'ETHERSCAN',
+    logo: 'https://assets.routescan.io/chains/flare/logo.png',
+    testNets: [
+      {
+        name: 'Flare Testnet Coston',
+        chainID: 16,
+        chain: 'test.flare',
+        domains: ['testnet.flarescan.com'],
+        siteName: 'ETHERSCAN',
+        logo: 'https://assets.routescan.io/chains/flare/logo.png'
+      }
+    ]
+  },
+  {
+    name: 'Songbird',
+    chainID: 19,
+    chain: 'songbird',
+    domains: ['songbird.flarescan.com'],
+    siteName: 'ETHERSCAN',
+    logo: 'https://assets.routescan.io/chains/songbird/logo.png'
+  },
+  {
+    name: 'Chiliz',
+    chainID: 88888,
+    chain: 'chiliz',
+    domains: ['chiliscan.com'],
+    siteName: 'ETHERSCAN',
+    logo: 'https://assets.routescan.io/chains/chiliz/logo.png',
+    testNets: [
+      {
+        name: 'Chiliz Spicy Testnet',
+        chainID: 88882,
+        chain: 'test.chiliz',
+        domains: ['testnet.chiliscan.com'],
+        siteName: 'ETHERSCAN',
+        logo: 'https://assets.routescan.io/chains/chiliz/logo.png'
+      }
+    ]
+  },
+  {
+    name: 'Metis',
+    chainID: 1088,
+    chain: 'metis',
+    domains: ['explorer.metis.com'],
+    siteName: 'ETHERSCAN',
+    logo: 'https://assets.routescan.io/chains/metis/logo.png',
+    testNets: [
+      {
+        name: 'Metis Sepolia',
+        chainID: 59902,
+        chain: 'test.metis',
+        domains: ['testnet.explorer.metis.com'],
+        siteName: 'ETHERSCAN',
+        logo: 'https://assets.routescan.io/chains/metis/logo.png'
+      }
+    ]
+  },
+  {
+    name: 'Boba',
+    chainID: 288,
+    chain: 'boba',
+    domains: ['bobascan.com'],
+    siteName: 'ETHERSCAN',
+    logo: 'https://assets.routescan.io/chains/boba/logo.png',
+    testNets: [
+      {
+        name: 'Boba Testnet',
+        chainID: 2888,
+        chain: 'test.boba',
+        domains: ['testnet.bobascan.com'],
+        siteName: 'ETHERSCAN',
+        logo: 'https://assets.routescan.io/chains/boba/logo.png'
+      }
+    ]
+  },
+  {
     name: 'Optimism',
     chainID: 10,
     chain: 'optimism',


### PR DESCRIPTION
## Summary

Adds support for block explorers operated by [Routescan](https://routescan.io/), as requested in #14.

### Explorers added

| Explorer | Domain | Chain | Chain ID | Testnet |
|----------|--------|-------|----------|---------|
| Snowtrace | snowtrace.io | Avalanche C-Chain | 43114 | testnet.snowtrace.io (Fuji, 43113) |
| Flarescan | flarescan.com | Flare | 14 | testnet.flarescan.com (Coston, 16) |
| Flarescan | songbird.flarescan.com | Songbird | 19 | — |
| Chiliscan | chiliscan.com | Chiliz | 88888 | testnet.chiliscan.com (Spicy, 88882) |
| Metis Explorer | explorer.metis.com | Metis Andromeda | 1088 | testnet.explorer.metis.com (Sepolia, 59902) |
| Bobascan | bobascan.com | Boba Ethereum | 288 | testnet.bobascan.com (2888) |

### Implementation details

All Routescan explorers use **Etherscan-compatible URL structures** (`/address/`, `/tx/`, `/block/`, etc.), so they are configured with `siteName: 'ETHERSCAN'` — no new page parsers needed.

Snowtrace (`snowtrace.io`) is added **alongside** the existing `snowscan.xyz` entry. Both are valid Avalanche C-Chain explorers (Routescan-operated and Etherscan-operated respectively).

### Files changed

- `src/common/config/allowlist.ts` — URL patterns for content script injection
- `src/common/constants/support.ts` — chain definitions in `EXT_SUPPORT_WEB_LIST`
- `manifest.config.ts` — dev-mode content script matches

### Routescan API compatibility

Routescan offers both [Etherscan-compatible APIs](https://routescan.io/documentation/api/etherscan-like/accounts) and [REST APIs](https://routescan.io/documentation/api-swagger). The Etherscan-compatible API does not require sign-up or API keys for the free tier.

Closes #14